### PR TITLE
sd - put for ucsborganizations

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBOrganizationController.java
@@ -94,4 +94,31 @@ public class UCSBOrganizationController extends ApiController{
         return organizations;
     }
 
+    /**
+     * Update a single organization. Accessible only to users with the role "ROLE_ADMIN".
+     * @param orgCode code of the organization
+     * @param incoming the new organization contents
+     * @return the updated commons object
+     */
+    @Operation(summary= "Update a single organization")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PutMapping("")
+    public UCSBOrganization updateOrg(
+            @Parameter(name="orgCode") @RequestParam String orgCode,
+            @RequestBody @Valid UCSBOrganization incoming) {
+
+        UCSBOrganization organization = ucsbOrganizationRepository.findById(orgCode)
+                .orElseThrow(() -> new EntityNotFoundException(UCSBOrganization.class, orgCode));
+
+  
+        organization.setOrgTranslationShort(incoming.getOrgTranslationShort());
+        organization.setOrgTranslation(incoming.getOrgTranslation());
+        organization.setInactive(incoming.getInactive());
+        ucsbOrganizationRepository.save(organization);
+
+        return organization;
+    }
+
+
+
 }


### PR DESCRIPTION
Closes #17 

In this PR,  put operations for the UCSB Organizations controller so that we will be able to edit existing organizations.
![image](https://github.com/user-attachments/assets/b3d00162-3346-4a67-b8d9-03181b72e674)
 