### PR TITLE
sl - add GET and tests on articles

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -1,13 +1,19 @@
 package edu.ucsb.cs156.example.controllers;
 
+import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.ucsb.cs156.example.models.CurrentUser;
 import edu.ucsb.cs156.example.services.CurrentUserService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.Map;
@@ -51,4 +57,6 @@ public abstract class ApiController {
       "message", e.getMessage()
     );
   }
+
+
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ApiController.java
@@ -1,19 +1,13 @@
 package edu.ucsb.cs156.example.controllers;
 
-import edu.ucsb.cs156.example.entities.UCSBDate;
 import edu.ucsb.cs156.example.errors.EntityNotFoundException;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import edu.ucsb.cs156.example.models.CurrentUser;
 import edu.ucsb.cs156.example.services.CurrentUserService;
-import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import java.util.Map;
@@ -57,6 +51,4 @@ public abstract class ApiController {
       "message", e.getMessage()
     );
   }
-
-
 }

--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -97,4 +97,29 @@ public class ArticlesController extends ApiController{
         return savedArticles;
     }
 
+    /**
+    * Get a single article by id
+    * 
+    * @param id the id of the article
+    * @return a Articles
+    */
+    @Operation(summary= "Get a single article")
+    @PreAuthorize("hasRole('ROLE_USER')")
+    @GetMapping("")
+    public Articles getById(
+            @Parameter(name="id") @RequestParam Long id) {
+         Articles article = articlesRepository.findById(id)
+               .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+        return article;
+  }
+
+
+
+
+
+
+
+
+    
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -141,6 +141,63 @@ public class ArticlesControllerTests extends ControllerTestCase {
         assertEquals(expectedJson, responseString);
     }
     
+    @Test
+    public void logged_out_users_cannot_get_by_id() throws Exception {
+            mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().is(403)); // logged out users can't get by id
+    }
 
 
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_exist() throws Exception {
+
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2025-04-21T17:00:00");
+    
+            Articles article1 = Articles.builder()
+                    .title("firstArticles")
+                    .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+                    .explanation("sl-updated")
+                    .email("shuang_li@ucsb.edu")
+                    .dateAdded(ldt1)
+                    .build();
+
+            when(articlesRepository.findById(eq(7L))).thenReturn(Optional.of(article1));
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+
+            verify(articlesRepository, times(1)).findById(eq(7L));
+            String expectedJson = mapper.writeValueAsString(article1);
+            String responseString = response.getResponse().getContentAsString();
+            assertEquals(expectedJson, responseString);
+
+    }
+
+
+
+    @WithMockUser(roles = { "USER" })
+    @Test
+    public void test_that_logged_in_user_can_get_by_id_when_the_id_does_not_exist() throws Exception {
+
+            // arrange
+
+            when(articlesRepository.findById(eq(7L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(get("/api/articles?id=7"))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+
+            verify(articlesRepository, times(1)).findById(eq(7L));
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("EntityNotFoundException", json.get("type"));
+            assertEquals("Articles with id 7 not found", json.get("message"));
+    }
 }


### PR DESCRIPTION
closes  #40 

Add another endpoint to the Articles controller, one that allows us to get an article by its id.

<img width="589" alt="image" src="https://github.com/user-attachments/assets/0d24d7ff-b81a-4aeb-9d7f-94631143ab38" />
