### PR TITLE
sl - add DELTET and test in articlesController

### DIFF
--- a/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/ArticlesController.java
@@ -142,4 +142,23 @@ public class ArticlesController extends ApiController{
         return article;
     }
 
+    /**
+     * Delete a Article
+     * 
+     * @param id the id of the article to delete
+     * @return a message indicating the article was deleted
+     */
+    @Operation(summary= "Delete a Article")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @DeleteMapping("")
+    public Object deleteArticle(
+            @Parameter(name="id") @RequestParam Long id) {
+        Articles article = articlesRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException(Articles.class, id));
+
+                articlesRepository.delete(article);
+        return genericMessage("Articles with id %s deleted".formatted(id));
+    }
+
+
 }

--- a/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/ArticlesControllerTests.java
@@ -281,4 +281,59 @@ public class ArticlesControllerTests extends ControllerTestCase {
             assertEquals("Articles with id 67 not found", json.get("message"));
 
     }
+
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_can_delete_a_article() throws Exception {
+            // arrange
+
+            LocalDateTime ldt1 = LocalDateTime.parse("2022-01-03T00:00:00");
+
+            Articles article1 = Articles.builder()
+            .title("firstArticles")
+            .url("https://github.com/ucsb-cs156-s25/team01-s25-11/commit/8e28ad3216e5156bb0ffbd67164f761635920f41")
+            .explanation("sl-updated")
+            .email("shuang_li@ucsb.edu")
+            .dateAdded(ldt1)
+            .build();
+
+
+            when(articlesRepository.findById(eq(15L))).thenReturn(Optional.of(article1));
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/articles?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isOk()).andReturn();
+
+            // assert
+            verify(articlesRepository, times(1)).findById(15L);
+            verify(articlesRepository, times(1)).delete(eq(article1));
+
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Articles with id 15 deleted", json.get("message"));
+    }
+
+    @WithMockUser(roles = { "ADMIN", "USER" })
+    @Test
+    public void admin_tries_to_delete_non_existant_ucsbdate_and_gets_right_error_message()
+                    throws Exception {
+            // arrange
+
+            when(articlesRepository.findById(eq(15L))).thenReturn(Optional.empty());
+
+            // act
+            MvcResult response = mockMvc.perform(
+                            delete("/api/articles?id=15")
+                                            .with(csrf()))
+                            .andExpect(status().isNotFound()).andReturn();
+
+            // assert
+            verify(articlesRepository, times(1)).findById(15L);
+            Map<String, Object> json = responseToJson(response);
+            assertEquals("Articles with id 15 not found", json.get("message"));
+    }
+
+
 }


### PR DESCRIPTION
Closes #42 
In this PR, add the delete operations to the Articles Controller.

<img width="627" alt="image" src="https://github.com/user-attachments/assets/8cd242ee-f728-4fee-bcad-61e52bf99b64" />
